### PR TITLE
tools/py-build: 0.1.1 refactor

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,6 +4,9 @@
 
 ## tools/py-build
 
--   [ ] Add support for sanitizers and tools like `cppcheck`.
+-   [ ] Add support for sanitizers and static analysis tools like `cppcheck`.
+-   [ ] Add a way to build all targets, instead of selecting just one.
+-   [ ] Make the output of the tool neater.
+-   [ ] Refactor into smaller types and functions and make it more readable.
 
 ## tools/map-editor

--- a/tools/py-build/build.default.yaml
+++ b/tools/py-build/build.default.yaml
@@ -11,7 +11,7 @@ project:
     language: 'c'
 
     dirs:
-        # Target destionation path for the binary/library
+        # Target destination path for the binary/library
         # NOTE: if any profiles are specified
         # their names will be appended to this path
         # like 'target/debug' and 'target/release'

--- a/tools/py-build/pyproject.toml
+++ b/tools/py-build/pyproject.toml
@@ -1,17 +1,17 @@
 [tool.poetry]
 name = "py-build"
-version = "0.1.0"
+version = "0.1.1"
 description = "Simple build system"
 authors = ["claymore <marekczjk@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "3.8.9"
 colorama = "^0.4.4"
+docopt = "^0.6.2"
 flatdict = "^4.0.1"
 python-dotenv = "^0.17.0"
 PyYAML = "^5.4.1"
 structlog = "^21.1.0"
-docopt = "^0.6.2"
 
 [tool.poetry.dev-dependencies]
 

--- a/tools/py-build/src/py-build.py
+++ b/tools/py-build/src/py-build.py
@@ -6,12 +6,17 @@ Builds C/C++ projects based on YAML config.
 
 Usage:
     py-build.py [--help]
-    py-build.py clean <config>
-    py-build.py build <config>
-    py-build.py run <config>
+    py-build.py clean <config> 
+    py-build.py build <config> <profile>
+    py-build.py run <config> <profile>
 
 Options:
     --help              Shows this screen.
+
+Input:
+    <config>            Path to configuration file
+    <profile>           What profile we're building
+                        (as defined in the config)
 
 Subcommands:
     clean               Cleans build and output directories.
@@ -58,6 +63,10 @@ def main():
 
         # Initialize main `Builder` object
         builder = Builder(config_path)
+
+        # Selected target profile
+        target = args['<profile>']
+        builder.set_target(target)
 
         # Entry point
         # =========================


### PR DESCRIPTION
The build tool will now take as an argument a profile to build. This marks it as active and the build that follows will only include the selected profile.

The build method has also been split into two smaller functions which first build the source files into object files and then those get linked together in a final compile in the second function.

For now the tool isn't yet able to run the compiled binary and perhaps the entire process relies too much on a given platform.
