### PR TITLE
tools/map-editor: Template files from another project

### DIFF
--- a/tools/map-editor/src/public/scripts/main.ts
+++ b/tools/map-editor/src/public/scripts/main.ts
@@ -1,0 +1,67 @@
+// Since I can't figure out how to get tsc to compile this client-side code with
+// support for the 'import' and 'require' statement, I'm forced to put all the code
+// into one file. If someone finds a good way to do this, without re-doing the
+// directory structure of the entire project, feel free to create a PR.
+//
+// Sorry in advance.
+
+// ==================================
+// = Utility types and functions ====
+// ==================================
+// Used for passing around references
+// to the context and canvas, also used
+// for passing around various configuration options
+// and not having to type out the long types every time
+type CanvasRef = {
+    canvas: {
+        object: HTMLCanvasElement;
+        context: CanvasRenderingContext2D;
+        dimensions: [number, number];
+    };
+};
+
+// Returns a given element in the DOM
+const $ = (what: string): HTMLElement | null => {
+    return document.querySelector(what);
+};
+
+// Returns a NodeList of all selected elements in DOM
+const _ = (what: string): NodeListOf<Element> => {
+    return document.querySelectorAll(what);
+};
+
+// ==========================
+// = Main initialization ====
+// ==========================
+(function () {
+    const init = () => {
+        // Get the main canvas viewport and its context
+        const viewport = $('canvas#viewport') as HTMLCanvasElement;
+        const context = viewport?.getContext('2d') as CanvasRenderingContext2D;
+
+        // Get the dimensions of the page
+        // and dynamically change the dimensions
+        // of the canvas
+        const { width, height } = viewport?.getBoundingClientRect();
+        viewport.width = width;
+        viewport.height = height;
+
+        // Translate it before performing any drawing/manipulation
+        // to avoid blurry lines and weird scaling
+        context.translate(0.5, 0.5);
+
+        const viewport_ref: CanvasRef = {
+            canvas: {
+                object: viewport,
+                context: context,
+                dimensions: [width, height],
+            },
+        };
+
+        // Retranslate it
+        context.translate(-0.5, -0.5);
+    };
+
+    // Make sure the DOM is loaded before we try to manipulate it
+    window.addEventListener('DOMContentLoaded', init);
+})();

--- a/tools/map-editor/src/public/styles/base.scss
+++ b/tools/map-editor/src/public/styles/base.scss
@@ -1,0 +1,52 @@
+// ====================
+// = Global styles ====
+// ====================
+@use 'global/reset';
+@use 'global/variables' as *;
+@use 'global/utils' as *;
+@use 'global/fonts';
+
+// ===========================
+// = Main page stylesheet ====
+// ===========================
+div#wrapper,
+body,
+html {
+    @extend %root-container;
+
+    position: relative;
+
+    flex-direction: row;
+
+    width: 100%;
+    height: 100%;
+
+    background: $main-bg;
+    color: $main-fg;
+
+    font-family: $stylish-font;
+
+    div#base {
+        @extend %center-container;
+
+        position: relative;
+
+        flex-direction: row;
+        justify-content: flex-start;
+
+        width: 100%;
+        height: calc(100% - #{$topbar-height} - #{$status-height});
+
+        background: $secondary-bg;
+        color: $secondary-fg;
+
+        canvas {
+            @extend %center-container;
+
+            position: relative;
+
+            width: calc(100% - (#{$toolbar-width} * 2));
+            height: 100%;
+        }
+    }
+}

--- a/tools/map-editor/src/public/styles/global/_fonts.scss
+++ b/tools/map-editor/src/public/styles/global/_fonts.scss
@@ -1,0 +1,2 @@
+@import 'https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap';
+@import 'https://fonts.googleapis.com/css2?family=Titillium+Web:ital,wght@0,200;0,300;0,400;0,600;0,700;1,200;1,300;1,400;1,600;1,700&display=swap';

--- a/tools/map-editor/src/public/styles/global/_reset.scss
+++ b/tools/map-editor/src/public/styles/global/_reset.scss
@@ -1,0 +1,129 @@
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    vertical-align: baseline;
+}
+
+// HTML5 display-role reset for older browsers
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+    display: block;
+}
+
+body {
+    line-height: 1;
+}
+
+ol,
+ul {
+    list-style: none;
+}
+
+blockquote,
+q {
+    quotes: none;
+}
+
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+    content: '';
+    content: none;
+}
+
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}

--- a/tools/map-editor/src/public/styles/global/_utils.scss
+++ b/tools/map-editor/src/public/styles/global/_utils.scss
@@ -1,0 +1,52 @@
+@use 'variables' as *;
+
+// =====================
+// = Utility mixins ====
+// =====================
+@mixin horizontal-shadow {
+    box-shadow: 0rem 0.5rem 0.5rem 0rem $shadow-color;
+}
+
+@mixin rev-horizontal-shadow {
+    box-shadow: 0rem -0.5rem 0.5rem 0rem $shadow-color;
+}
+
+@mixin vertical-shadow {
+    box-shadow: 0.5rem 0rem 0.5rem 0rem $shadow-color;
+}
+
+@mixin rev-vertical-shadow {
+    box-shadow: -0.5rem 0rem 0.5rem 0rem $shadow-color;
+}
+
+@mixin default-animation {
+    transition: all 0.08s linear;
+}
+
+@mixin apply-animation {
+    * {
+        @include default-animation;
+    }
+}
+
+// ================================
+// = Common virtual components ====
+// ================================
+%root-container {
+    width: 100%;
+    height: 100%;
+    font-family: $main-font;
+    color: $main-fg;
+    overflow-x: hidden;
+    scroll-behavior: smooth;
+    text-rendering: optimizeLegibility;
+}
+
+%center-container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+}

--- a/tools/map-editor/src/public/styles/global/_variables.scss
+++ b/tools/map-editor/src/public/styles/global/_variables.scss
@@ -1,0 +1,35 @@
+// =============
+// = Colors ====
+// =============
+$main-bg: rgb(32, 35, 37);
+$main-fg: rgb(212, 238, 255);
+$accent: rgb(65, 149, 228);
+
+$neutral-gray: hsl(204, 0%, 30%);
+
+$secondary-bg: rgb(193, 212, 229);
+$secondary-fg: rgb(30, 33, 35);
+
+$accent-bg: rgb(23, 55, 85);
+$accent-fg: rgb(131, 194, 255);
+
+$shadow-color: rgba(0, 0, 0, 0.102);
+$hard-shadow: rgba(0, 0, 0, 0.749);
+
+// ============
+// = Fonts ====
+// ============
+$main-font: 'Roboto', sans-serif;
+$secondary-font: 'Roboto Slab', serif;
+
+$stylish-font: 'Titillium Web', sans-serif;
+
+// =================
+// = Dimensions ====
+// =================
+$common-icon-size: 16px;
+
+$topbar-height: calc(#{$common-icon-size} * 2);
+$status-height: calc(#{$common-icon-size} * 2);
+$toolbar-width: calc(#{$common-icon-size} * 2);
+$sidebar-width: calc(#{$common-icon-size} * 2);

--- a/tools/map-editor/views/_layout.pug
+++ b/tools/map-editor/views/_layout.pug
@@ -21,6 +21,7 @@ html(lang='en')
                 h1 This map editor will not function without JavaScript support!
 
             //- Main render viewport.
-            block viewport
+            #base
+                block viewport
 
         script(src='/scripts/main.js', type='module')

--- a/tools/map-editor/views/index.pug
+++ b/tools/map-editor/views/index.pug
@@ -1,4 +1,4 @@
 extends _layout
 
 block viewport
-    canvas
+    canvas#viewport

--- a/tools/py-build/README.txt
+++ b/tools/py-build/README.txt
@@ -4,5 +4,18 @@ I made this tool just so I don't have to deal with CMake and linking shenanigans
 This isn't a production-ready tool for large projects. It's designed for building smaller projects
 that don't rely on CMake.
 
-Note that this project uses poetry (https://python-poetry.org/) which makes it easier
+Note that this project uses *poetry* which makes it easier
 to deal with dependencies and virtual environments. 
+
+Prerequisites:
+    - poetry 1.1.5    (https://python-poetry.org/)
+    - python 3.8.9    (https://www.python.org/)
+
+Usage:
+    - Invoke shell in the tools/py-build directory.
+
+    - To see the usage and help menu run the following command:
+        '$ poetry run python src/py-build.py --help'
+
+    - Build project by specifying the config file and target profile using
+        '$ poetry run python src/py-build.py [CONFIG] [TARGET]'


### PR DESCRIPTION
Added some global styles and init code for viewport and canvas manipulation from a previous project.

This PR lets us actually run and test the web app, as opposed to scripts and the page throwing errors due to missing files.

Note that the main typescript initialization file cannot use imports or require statements, since its code is ran in the browser. I don't know how to fix this yet, so I'm just going to throw all the code into a the single `main.ts` file.