### PR TITLE
repo: Fix language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 *                   text=auto
 
-/game/assets/**		linguist-vendored
+/calamity/vendor/**		linguist-vendored
 
 *.bash              text eol=lf
 *.bat               text eol=crlf


### PR DESCRIPTION
.gitattributes had the wrong paths to vendor libraries. Now it's been fixed and points to the right path.