### PR TITLE
calamity: Utilize `std::variant` for parsing and calling functors

### DIFF
--- a/calamity/include/zcommon.hpp
+++ b/calamity/include/zcommon.hpp
@@ -38,6 +38,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 #include <vector>
 
 // helps to differentiate between different

--- a/calamity/src/yaml/lookup.hpp
+++ b/calamity/src/yaml/lookup.hpp
@@ -1,0 +1,160 @@
+#pragma once
+
+#include "zcommon.hpp"
+
+// TODO: Move to a separate type utils file
+// ====================
+// = Utility types ====
+// ====================
+
+namespace Types {
+    struct Vec2 {
+        double x;
+        double y;
+    };
+
+    struct Entity {
+        Vec2 pos;
+        u16  angle;
+        u16  type;
+    };
+
+    struct Line {
+        u16 start;
+        u16 end;
+    };
+
+    struct Side {
+        u16 sector_index;
+    };
+
+    struct Sector {
+        i16 floor_height;
+        i16 ceiling_height;
+
+        std::string floor_texture;
+        std::string ceiling_texture;
+
+        u8 light_level;
+    };
+
+    struct LevelData {
+        std::vector<Entity> entities;
+        std::vector<Vec2>   vertices;
+        std::vector<Line>   lines;
+        std::vector<Side>   sides;
+        std::vector<Sector> sectors;
+    };
+
+    // Conglomerate type for dealing with all lookups
+    template <typename T> struct ParseObject {
+        using RetVal  = std::vector<T>;
+        using Functor = std::function<RetVal(const std::vector<std::string>&, usize)>;
+
+        u32     m_hash;
+        Functor m_functor;
+
+        ParseObject(u32 hash, Functor functor) {
+            this->m_hash    = hash;
+            this->m_functor = functor;
+        }
+
+        auto get_hash() -> u32 {
+            return this->m_hash;
+        }
+
+        auto get_func() -> Functor {
+            return this->m_functor;
+        }
+    };
+
+} // namespace Types
+
+// ========================
+// = Utility functions ====
+// ========================
+namespace Funcs {
+    using namespace Types;
+
+    std::vector<Entity> parse_ents(const std::vector<std::string>& data, usize index) {
+        std::vector<Entity> result;
+        for (usize i = index; i < data.size(); ++i) {
+            // We reached the end of the stream for this data block
+            if (data[i] == "\n" || data[i] == "") {
+                break;
+            }
+
+            std::cout << "Ent: \"" << data[i] << "\"" << std::endl;
+        }
+        return result;
+    }
+
+    std::vector<Vec2> parse_verts(const std::vector<std::string>& data, usize index) {
+        std::vector<Vec2> result;
+        for (usize i = index; i < data.size(); ++i) {
+            // We reached the end of the stream for this data block
+            if (data[i] == "\n" || data[i] == "") {
+                break;
+            }
+
+            std::cout << "Vert: \"" << data[i] << "\"" << std::endl;
+        }
+        return result;
+    }
+
+    std::vector<Line> parse_lines(const std::vector<std::string>& data, usize index) {
+        std::vector<Line> result;
+        for (usize i = index; i < data.size(); ++i) {
+            // We reached the end of the stream for this data block
+            if (data[i] == "\n" || data[i] == "") {
+                break;
+            }
+
+            std::cout << "Line: \"" << data[i] << "\"" << std::endl;
+        }
+        return result;
+    }
+
+    std::vector<Side> parse_sides(const std::vector<std::string>& data, usize index) {
+        std::vector<Side> result;
+        for (usize i = index; i < data.size(); ++i) {
+            // We reached the end of the stream for this data block
+            if (data[i] == "\n" || data[i] == "") {
+                break;
+            }
+
+            std::cout << "Side: \"" << data[i] << "\"" << std::endl;
+        }
+        return result;
+    }
+
+    std::vector<Sector> parse_sectors(const std::vector<std::string>& data, usize index) {
+        std::vector<Sector> result;
+        for (usize i = index; i < data.size(); ++i) {
+            // We reached the end of the stream for this data block
+            if (data[i] == "\n" || data[i] == "") {
+                break;
+            }
+
+            std::cout << "Sector: \"" << data[i] << "\"" << std::endl;
+        }
+        return result;
+    }
+} // namespace Funcs
+
+namespace Tables {
+    using namespace Types;
+    using namespace Funcs;
+
+    using ParseVariant = std::variant<ParseObject<Entity>, ParseObject<Vec2>, ParseObject<Line>,
+                                      ParseObject<Side>, ParseObject<Sector>>;
+
+    const std::unordered_map<std::string, ParseVariant> PARSING_ACTIONS = {
+        // Identification key     Type    Hash        Parsing function
+        { "ENTITIES", ParseObject<Entity>(0xf60f939, parse_ents) },
+        { "VERTICES", ParseObject<Vec2>(0x2283e993, parse_verts) },
+        { "LINES", ParseObject<Line>(0xb7643fa, parse_lines) },
+        { "SIDES", ParseObject<Side>(0x1bc4e497, parse_sides) },
+        { "SECTORS", ParseObject<Sector>(0xeb608602, parse_sectors) },
+    };
+} // namespace Tables

--- a/calamity/src/yaml/parser.cpp
+++ b/calamity/src/yaml/parser.cpp
@@ -1,96 +1,42 @@
 #include "parser.hpp"
+#include "lookup.hpp"
 #include "utils/hash.hpp"
 
 namespace YAML {
-    const std::unordered_map<std::string, u32> LEVEL_TAGS = {
-        { "ENTITIES", 0xb17ff827 }, { "VERTICES", 0xe8fc34a1 }, { "LINES", 0xf039db38 },
-        { "SIDES", 0xa5c9025 },     { "SECTORS", 0x389eb4b0 },
-    };
-
-    auto parse_ents(const std::vector<std::string>& data, usize index) -> void {
-        for (usize i = index; i < data.size(); ++i) {
-            // We reached the end of the stream for this data block
-            if (data[i] == "\n" || data[i] == "") {
-                return;
-            }
-
-            std::cout << "Ent: \"" << data[i] << "\"" << std::endl;
-        }
-    }
-
-    auto parse_verts(const std::vector<std::string>& data, usize index) -> void {
-        for (usize i = index; i < data.size(); ++i) {
-            // We reached the end of the stream for this data block
-            if (data[i] == "\n" || data[i] == "") {
-                return;
-            }
-
-            std::cout << "Vert: \"" << data[i] << "\"" << std::endl;
-        }
-    }
-
-    auto parse_lines(const std::vector<std::string>& data, usize index) -> void {
-        for (usize i = index; i < data.size(); ++i) {
-            // We reached the end of the stream for this data block
-            if (data[i] == "\n" || data[i] == "") {
-                return;
-            }
-
-            std::cout << "Line: \"" << data[i] << "\"" << std::endl;
-        }
-    }
-
-    auto parse_sides(const std::vector<std::string>& data, usize index) -> void {
-        for (usize i = index; i < data.size(); ++i) {
-            // We reached the end of the stream for this data block
-            if (data[i] == "\n" || data[i] == "") {
-                return;
-            }
-
-            std::cout << "Side: \"" << data[i] << "\"" << std::endl;
-        }
-    }
-
-    auto parse_sectors(const std::vector<std::string>& data, usize index) -> void {
-        for (usize i = index; i < data.size(); ++i) {
-            // We reached the end of the stream for this data block
-            if (data[i] == "\n" || data[i] == "") {
-                return;
-            }
-
-            std::cout << "Sector: \"" << data[i] << "\"" << std::endl;
-        }
-    }
-
     auto parse(const std::vector<std::string>& data) -> void {
-        // Parse line by line
-        usize index = 0;
-        for (auto& i : data) {
-            // Check for the namespace id
-            if (Z_HashStr(i) == 0x254c893c) {
-                index += 1;
-                continue;
-            }
+        auto data_copy = data;
 
-            // Parse the known level tags
-            auto hash = Z_HashStr(i);
-            if (hash == LEVEL_TAGS.at("ENTITIES")) {
-                parse_ents(std::move(data), index);
-                continue;
-            } else if (hash == LEVEL_TAGS.at("VERTICES")) {
-                parse_verts(std::move(data), index);
-                continue;
-            } else if (hash == LEVEL_TAGS.at("LINES")) {
-                parse_lines(std::move(data), index);
-                continue;
-            } else if (hash == LEVEL_TAGS.at("SIDES")) {
-                parse_sides(std::move(data), index);
-                continue;
-            } else if (hash == LEVEL_TAGS.at("SECTORS")) {
-                parse_sectors(std::move(data), index);
-                continue;
-            } else {
-                index += 1;
+        // Strip all keys and values of their single quotes
+        for (auto& it : data_copy) {
+            it.erase(std::remove_if(it.begin(), it.end(), [](char x) { return '\'' == x; }),
+                     it.end());
+        }
+
+        // Iterate over all possible parsing actions.
+        for (auto&& [key, type] : Tables::PARSING_ACTIONS) {
+            // Iterate through the entire file line by line
+            for (auto it = data_copy.begin(); it < data_copy.end(); ++it) {
+                // Get the identification of a given line, using a hash function
+                auto key_ident = Z_HashStr(*it);
+
+                // Check for the namespace id hash
+                if (key_ident == 0xa8abfea0) {
+                    continue;
+                }
+
+                // Catch any possible candidates for parsing, using the predefined
+                // key -> event lookup table
+                std::visit(
+                    [&](auto val) {
+                        if (key_ident == val.get_hash()) {
+                            // Call the functor responsible for parsing
+                            auto index = it - data_copy.begin();
+                            auto func  = val.get_func();
+
+                            auto parsed = func(data_copy, index);
+                        }
+                    },
+                    type);
             }
         }
     }


### PR DESCRIPTION
Right now the only thing left is to parse the lines within each dictionary to construct the proper structure that corresponds with the type.