### PR TITLE
calamity: use std::any properly.

### DIFF
--- a/calamity/include/zcommon.hpp
+++ b/calamity/include/zcommon.hpp
@@ -14,6 +14,7 @@
 
 // C++ includes
 #include <algorithm>
+#include <any>
 #include <array>
 #include <chrono>
 #include <filesystem>

--- a/calamity/src/yaml/lookup.hpp
+++ b/calamity/src/yaml/lookup.hpp
@@ -3,19 +3,23 @@
 #include "types.hpp"
 
 namespace YAML::LUTs {
-    using namespace Types;
-    using Functor = std::function<void(const FuncArgs& args)>;
-    
+    using Types::FuncArgs;
+    using Types::Level::Entity;
+    using Types::Level::Line;
+    using Types::Level::Sector;
+    using Types::Level::Side;
+    using Types::Level::Vec2;
+
     // ===========================
     // = Functor lookup table ====
     // ===========================
 
     // Used for parsing different types of level objects from map files
-    static std::map<std::string, Functor> PARSER_FUNCTORS = {
-        { "PARSE_ENTS", [](const FuncArgs& args) { return parse_functor<Level::Entity>(args); } },
-        { "PARSE_VERTS", [](const FuncArgs& args) { return parse_functor<Level::Vec2>(args); } },
-        { "PARSE_LINES", [](const FuncArgs& args) { return parse_functor<Level::Line>(args); } },
-        { "PARSE_SIDES", [](const FuncArgs& args) { return parse_functor<Level::Side>(args); } },
-        { "PARSE_SECTORS", [](const FuncArgs& args) { return parse_functor<Level::Sector>(args); } },
+    static std::map<std::string, std::any> PARSER_FUNCTORS = {
+        { "PARSE_ENTS", [](const FuncArgs& args) { return Types::parse_functor<Entity>(args); } },
+        { "PARSE_VERTS", [](const FuncArgs& args) { return Types::parse_functor<Vec2>(args); } },
+        { "PARSE_LINES", [](const FuncArgs& args) { return Types::parse_functor<Line>(args); } },
+        { "PARSE_SIDES", [](const FuncArgs& args) { return Types::parse_functor<Side>(args); } },
+        { "PARSE_SECTORS", [](const FuncArgs& args) { return Types::parse_functor<Sector>(args); } },
     };
 } // namespace YAML::LUTs

--- a/calamity/src/yaml/lookup.hpp
+++ b/calamity/src/yaml/lookup.hpp
@@ -14,12 +14,24 @@ namespace YAML::LUTs {
     // = Functor lookup table ====
     // ===========================
 
+    // Forgive me god for I have sinned...
+    using LambdaEnt    = std::function<std::vector<Entity>(const FuncArgs&)>;
+    using LambdaVert   = std::function<std::vector<Vec2>(const FuncArgs&)>;
+    using LambdaLine   = std::function<std::vector<Line>(const FuncArgs&)>;
+    using LambdaSide   = std::function<std::vector<Side>(const FuncArgs&)>;
+    using LambdaSector = std::function<std::vector<Sector>(const FuncArgs&)>;
+
     // Used for parsing different types of level objects from map files
     static std::map<std::string, std::any> PARSER_FUNCTORS = {
-        { "PARSE_ENTS", [](const FuncArgs& args) { return Types::parse_functor<Entity>(args); } },
-        { "PARSE_VERTS", [](const FuncArgs& args) { return Types::parse_functor<Vec2>(args); } },
-        { "PARSE_LINES", [](const FuncArgs& args) { return Types::parse_functor<Line>(args); } },
-        { "PARSE_SIDES", [](const FuncArgs& args) { return Types::parse_functor<Side>(args); } },
-        { "PARSE_SECTORS", [](const FuncArgs& args) { return Types::parse_functor<Sector>(args); } },
+        { "PARSE_ENTS",
+          std::make_any<LambdaEnt>([](const FuncArgs& args) { return Types::parse_functor<Entity>(args); }) },
+        { "PARSE_VERTS",
+          std::make_any<LambdaVert>([](const FuncArgs& args) { return Types::parse_functor<Vec2>(args); }) },
+        { "PARSE_LINES",
+          std::make_any<LambdaLine>([](const FuncArgs& args) { return Types::parse_functor<Line>(args); }) },
+        { "PARSE_SIDES",
+          std::make_any<LambdaSide>([](const FuncArgs& args) { return Types::parse_functor<Side>(args); }) },
+        { "PARSE_SECTORS",
+          std::make_any<LambdaSector>([](const FuncArgs& args) { return Types::parse_functor<Sector>(args); }) },
     };
 } // namespace YAML::LUTs

--- a/calamity/src/yaml/parser.cpp
+++ b/calamity/src/yaml/parser.cpp
@@ -4,6 +4,7 @@
 
 namespace YAML {
     auto parse(std::vector<std::string>& data) -> void {
+        using namespace Types::Level;
         // Strip all single quotes and spaces
         for (auto& it : data) {
             it.erase(std::remove_if(it.begin(), it.end(), [](char x) { return '\'' == x; }), it.end());
@@ -18,20 +19,54 @@ namespace YAML {
             usize index = (it - data.begin()) + 1;
 
             if (current_line.rfind("ents", 0) == 0) {
+                using Functor = std::function<std::vector<Entity>(const Types::FuncArgs& args)>;
+
                 std::cout << "ENTITIES" << std::endl;
-                LUTs::PARSER_FUNCTORS["PARSE_ENTS"](Types::FuncArgs{ data, index });
+
+                // Sadly, we are forced to cast these constantly...
+                // Blame me for using std::any for this
+                // couldn't figure out how to use std::variant with it
+                auto    raw       = LUTs::PARSER_FUNCTORS["PARSE_ENTS"];
+                Functor processed = std::any_cast<Functor>(raw);
+
+                // acquire the result
+                std::vector<Entity> result = processed(Types::FuncArgs{ data, index });
             } else if (current_line.rfind("verts", 0) == 0) {
+                using Functor = std::function<std::vector<Vec2>(const Types::FuncArgs& args)>;
+
                 std::cout << "VERTICES" << std::endl;
-                LUTs::PARSER_FUNCTORS["PARSE_VERTS"](Types::FuncArgs{ data, index });
+
+                auto    raw       = LUTs::PARSER_FUNCTORS["PARSE_VERTS"];
+                Functor processed = std::any_cast<Functor>(raw);
+
+                std::vector<Vec2> result = processed(Types::FuncArgs{ data, index });
             } else if (current_line.rfind("lines", 0) == 0) {
+                using Functor = std::function<std::vector<Line>(const Types::FuncArgs& args)>;
+
                 std::cout << "LINES" << std::endl;
-                LUTs::PARSER_FUNCTORS["PARSE_LINES"](Types::FuncArgs{ data, index });
+
+                auto    raw       = LUTs::PARSER_FUNCTORS["PARSE_LINES"];
+                Functor processed = std::any_cast<Functor>(raw);
+
+                std::vector<Line> result = processed(Types::FuncArgs{ data, index });
             } else if (current_line.rfind("sides", 0) == 0) {
+                using Functor = std::function<std::vector<Side>(const Types::FuncArgs& args)>;
+
                 std::cout << "SIDES" << std::endl;
-                LUTs::PARSER_FUNCTORS["PARSE_SIDES"](Types::FuncArgs{ data, index });
+
+                auto    raw       = LUTs::PARSER_FUNCTORS["PARSE_SIDES"];
+                Functor processed = std::any_cast<Functor>(raw);
+
+                std::vector<Side> result = processed(Types::FuncArgs{ data, index });
             } else if (current_line.rfind("sectors", 0) == 0) {
+                using Functor = std::function<std::vector<Sector>(const Types::FuncArgs& args)>;
+
                 std::cout << "SECTORS" << std::endl;
-                LUTs::PARSER_FUNCTORS["PARSE_SECTORS"](Types::FuncArgs{ data, index });
+
+                auto    raw       = LUTs::PARSER_FUNCTORS["PARSE_SECTORS"];
+                Functor processed = std::any_cast<Functor>(raw);
+
+                std::vector<Sector> result = processed(Types::FuncArgs{ data, index });
             }
         }
     }

--- a/calamity/src/yaml/parser.cpp
+++ b/calamity/src/yaml/parser.cpp
@@ -26,38 +26,38 @@ namespace YAML {
                 // Sadly, we are forced to cast these constantly...
                 // Blame me for using std::any for this
                 // couldn't figure out how to use std::variant with it
-                auto    raw       = LUTs::PARSER_FUNCTORS["PARSE_ENTS"];
-                Functor processed = std::any_cast<Functor>(raw);
+                auto    raw     = LUTs::PARSER_FUNCTORS["PARSE_ENTS"];
+                Functor functor = std::any_cast<Functor>(raw);
 
                 // acquire the result
-                std::vector<Entity> result = processed(Types::FuncArgs{ data, index });
+                std::vector<Entity> result = functor(Types::FuncArgs{ data, index });
             } else if (current_line.rfind("verts", 0) == 0) {
                 using Functor = std::function<std::vector<Vec2>(const Types::FuncArgs& args)>;
 
                 std::cout << "VERTICES" << std::endl;
 
-                auto    raw       = LUTs::PARSER_FUNCTORS["PARSE_VERTS"];
-                Functor processed = std::any_cast<Functor>(raw);
+                auto    raw     = LUTs::PARSER_FUNCTORS["PARSE_VERTS"];
+                Functor functor = std::any_cast<Functor>(raw);
 
-                std::vector<Vec2> result = processed(Types::FuncArgs{ data, index });
+                std::vector<Vec2> result = functor(Types::FuncArgs{ data, index });
             } else if (current_line.rfind("lines", 0) == 0) {
                 using Functor = std::function<std::vector<Line>(const Types::FuncArgs& args)>;
 
                 std::cout << "LINES" << std::endl;
 
-                auto    raw       = LUTs::PARSER_FUNCTORS["PARSE_LINES"];
-                Functor processed = std::any_cast<Functor>(raw);
+                auto    raw     = LUTs::PARSER_FUNCTORS["PARSE_LINES"];
+                Functor functor = std::any_cast<Functor>(raw);
 
-                std::vector<Line> result = processed(Types::FuncArgs{ data, index });
+                std::vector<Line> result = functor(Types::FuncArgs{ data, index });
             } else if (current_line.rfind("sides", 0) == 0) {
                 using Functor = std::function<std::vector<Side>(const Types::FuncArgs& args)>;
 
                 std::cout << "SIDES" << std::endl;
 
-                auto    raw       = LUTs::PARSER_FUNCTORS["PARSE_SIDES"];
-                Functor processed = std::any_cast<Functor>(raw);
+                auto    raw     = LUTs::PARSER_FUNCTORS["PARSE_SIDES"];
+                Functor functor = std::any_cast<Functor>(raw);
 
-                std::vector<Side> result = processed(Types::FuncArgs{ data, index });
+                std::vector<Side> result = functor(Types::FuncArgs{ data, index });
             } else if (current_line.rfind("sectors", 0) == 0) {
                 using Functor = std::function<std::vector<Sector>(const Types::FuncArgs& args)>;
 

--- a/calamity/src/yaml/parser.cpp
+++ b/calamity/src/yaml/parser.cpp
@@ -19,7 +19,7 @@ namespace YAML {
             usize index = (it - data.begin()) + 1;
 
             if (current_line.rfind("ents", 0) == 0) {
-                using Functor = std::function<std::vector<Entity>(const Types::FuncArgs& args)>;
+                using Functor = LUTs::LambdaEnt;
 
                 std::cout << "ENTITIES" << std::endl;
 
@@ -32,7 +32,7 @@ namespace YAML {
                 // acquire the result
                 std::vector<Entity> result = functor(Types::FuncArgs{ data, index });
             } else if (current_line.rfind("verts", 0) == 0) {
-                using Functor = std::function<std::vector<Vec2>(const Types::FuncArgs& args)>;
+                using Functor = LUTs::LambdaVert;
 
                 std::cout << "VERTICES" << std::endl;
 
@@ -41,7 +41,7 @@ namespace YAML {
 
                 std::vector<Vec2> result = functor(Types::FuncArgs{ data, index });
             } else if (current_line.rfind("lines", 0) == 0) {
-                using Functor = std::function<std::vector<Line>(const Types::FuncArgs& args)>;
+                using Functor = LUTs::LambdaLine;
 
                 std::cout << "LINES" << std::endl;
 
@@ -50,7 +50,7 @@ namespace YAML {
 
                 std::vector<Line> result = functor(Types::FuncArgs{ data, index });
             } else if (current_line.rfind("sides", 0) == 0) {
-                using Functor = std::function<std::vector<Side>(const Types::FuncArgs& args)>;
+                using Functor = LUTs::LambdaSide;
 
                 std::cout << "SIDES" << std::endl;
 
@@ -59,7 +59,7 @@ namespace YAML {
 
                 std::vector<Side> result = functor(Types::FuncArgs{ data, index });
             } else if (current_line.rfind("sectors", 0) == 0) {
-                using Functor = std::function<std::vector<Sector>(const Types::FuncArgs& args)>;
+                using Functor = LUTs::LambdaSector;
 
                 std::cout << "SECTORS" << std::endl;
 

--- a/calamity/src/yaml/types.cpp
+++ b/calamity/src/yaml/types.cpp
@@ -9,10 +9,12 @@ namespace YAML::Types {
 
     template <>
     auto parse_functor<Level::Entity>(const FuncArgs& args) -> void {
+        Level::Entity ent     = {};
+        Level::Vec2   ent_pos = {};
+
+        std::vector<Level::Entity> entities;
         for (auto it = args.data.begin() + args.index; it < args.data.end(); ++it) {
-            // Get the current index (which line) from the iterator
-            usize       cur_idx = it - args.data.begin();
-            std::string line    = *it;
+            std::string line = *it;
 
             // Break when we hit newlines or empty strings
             // these signify the end of our parsing block
@@ -23,18 +25,32 @@ namespace YAML::Types {
             // If no "end of stream" markers have been found
             // parse the following lines as dictionaries in arrays.
             if (line.rfind('-', 0)) {
-                std::string value = line;
-
                 // Identify where in the string the value starts and key ends
-                auto pos = value.find(':', 0);
+                auto pos = line.find(':', 0);
 
-                // Erase it
-                value.erase(0, pos + 1);
+                // Split the string into a key-value pair
+                std::string key   = line.substr(0, pos);
+                std::string value = line.substr(pos + 1);
 
-                std::cout << "\tParsed: [" << value << "]" << std::endl;
+                // No switch statements for non-integral types...
+                if (key == "x") {
+                    ent_pos.x = std::stod(value);
+                } else if (key == "y") {
+                    ent_pos.y = std::stod(value);
+                } else if (key == "angle") {
+                    ent.angle = static_cast<u16>(std::stod(value));
+                } else if (key == "type") {
+                    ent.type = static_cast<u16>(std::stod(value));
+                }
+
+                std::cout << "\tParsed: [" << key << "]:[" << value << "]" << std::endl;
             } else {
                 continue;
             }
+
+            // Save the entity into a vector
+            ent.pos = ent_pos;
+            entities.push_back(ent);
         }
         return;
     }

--- a/calamity/src/yaml/types.cpp
+++ b/calamity/src/yaml/types.cpp
@@ -2,13 +2,14 @@
 
 namespace YAML::Types {
     template <class T>
-    auto parse_functor(const FuncArgs& args) -> void {
+    auto parse_functor(const FuncArgs& args) -> std::vector<T> {
+        std::vector<T> result;
         std::cerr << "Called unspecialized functor." << std::endl;
-        return;
+        return result;
     }
 
     template <>
-    auto parse_functor<Level::Entity>(const FuncArgs& args) -> void {
+    auto parse_functor<Level::Entity>(const FuncArgs& args) -> std::vector<Level::Entity> {
         Level::Entity ent     = {};
         Level::Vec2   ent_pos = {};
 
@@ -52,18 +53,178 @@ namespace YAML::Types {
             ent.pos = ent_pos;
             entities.push_back(ent);
         }
-        return;
+        return entities;
     }
 
     template <>
-    auto parse_functor<Level::Vec2>(const FuncArgs& args) -> void {}
+    auto parse_functor<Level::Vec2>(const FuncArgs& args) -> std::vector<Level::Vec2> {
+        Level::Vec2 vert = {};
+
+        std::vector<Level::Vec2> verts;
+        for (auto it = args.data.begin() + args.index; it < args.data.end(); ++it) {
+            std::string line = *it;
+
+            // Break when we hit newlines or empty strings
+            // these signify the end of our parsing block
+            if (line == "\n" || line == "") {
+                break;
+            }
+
+            // If no "end of stream" markers have been found
+            // parse the following lines as dictionaries in arrays.
+            if (line.rfind('-', 0)) {
+                // Identify where in the string the value starts and key ends
+                auto pos = line.find(':', 0);
+
+                // Split the string into a key-value pair
+                std::string key   = line.substr(0, pos);
+                std::string value = line.substr(pos + 1);
+
+                // No switch statements for non-integral types...
+                if (key == "x") {
+                    vert.x = std::stod(value);
+                } else if (key == "y") {
+                    vert.y = std::stod(value);
+                }
+
+                std::cout << "\tParsed: [" << key << "]:[" << value << "]" << std::endl;
+            } else {
+                continue;
+            }
+
+            // Save the entity into a vector
+            verts.push_back(vert);
+        }
+        return verts;
+    }
 
     template <>
-    auto parse_functor<Level::Line>(const FuncArgs& args) -> void {}
+    auto parse_functor<Level::Line>(const FuncArgs& args) -> std::vector<Level::Line> {
+        Level::Line line_obj = {};
+
+        std::vector<Level::Line> lines;
+        for (auto it = args.data.begin() + args.index; it < args.data.end(); ++it) {
+            std::string line = *it;
+
+            // Break when we hit newlines or empty strings
+            // these signify the end of our parsing block
+            if (line == "\n" || line == "") {
+                break;
+            }
+
+            // If no "end of stream" markers have been found
+            // parse the following lines as dictionaries in arrays.
+            if (line.rfind('-', 0)) {
+                // Identify where in the string the value starts and key ends
+                auto pos = line.find(':', 0);
+
+                // Split the string into a key-value pair
+                std::string key   = line.substr(0, pos);
+                std::string value = line.substr(pos + 1);
+
+                // No switch statements for non-integral types...
+                if (key == "v1") {
+                    line_obj.start = static_cast<u16>(std::stoul(value));
+                } else if (key == "v2") {
+                    line_obj.end = static_cast<u16>(std::stoul(value));
+                }
+
+                std::cout << "\tParsed: [" << key << "]:[" << value << "]" << std::endl;
+            } else {
+                continue;
+            }
+
+            // Save the entity into a vector
+            lines.push_back(line_obj);
+        }
+        return lines;
+    }
 
     template <>
-    auto parse_functor<Level::Side>(const FuncArgs& args) -> void {}
+    auto parse_functor<Level::Side>(const FuncArgs& args) -> std::vector<Level::Side> {
+        Level::Side side = {};
+
+        std::vector<Level::Side> sides;
+        for (auto it = args.data.begin() + args.index; it < args.data.end(); ++it) {
+            std::string line = *it;
+
+            // Break when we hit newlines or empty strings
+            // these signify the end of our parsing block
+            if (line == "\n" || line == "") {
+                break;
+            }
+
+            // If no "end of stream" markers have been found
+            // parse the following lines as dictionaries in arrays.
+            if (line.rfind('-', 0)) {
+                // Identify where in the string the value starts and key ends
+                auto pos = line.find(':', 0);
+
+                // Split the string into a key-value pair
+                std::string key   = line.substr(0, pos);
+                std::string value = line.substr(pos + 1);
+
+                // No switch statements for non-integral types...
+                if (key == "sector") {
+                    side.sector_index = static_cast<u16>(std::stoul(value));
+                }
+
+                std::cout << "\tParsed: [" << key << "]:[" << value << "]" << std::endl;
+            } else {
+                continue;
+            }
+
+            // Save the entity into a vector
+            sides.push_back(side);
+        }
+        return sides;
+    }
 
     template <>
-    auto parse_functor<Level::Sector>(const FuncArgs& args) -> void {}
+    auto parse_functor<Level::Sector>(const FuncArgs& args) -> std::vector<Level::Sector> {
+        Level::Sector sector = {};
+
+        std::vector<Level::Sector> sectors;
+        for (auto it = args.data.begin() + args.index; it < args.data.end(); ++it) {
+            std::string line = *it;
+
+            // Break when we hit newlines or empty strings
+            // these signify the end of our parsing block
+            if (line == "\n" || line == "") {
+                break;
+            }
+
+            // If no "end of stream" markers have been found
+            // parse the following lines as dictionaries in arrays.
+            if (line.rfind('-', 0)) {
+                // Identify where in the string the value starts and key ends
+                auto pos = line.find(':', 0);
+
+                // Split the string into a key-value pair
+                std::string key   = line.substr(0, pos);
+                std::string value = line.substr(pos + 1);
+
+                // No switch statements for non-integral types...
+                if (key == "floor_height") {
+                    sector.floor_height = static_cast<i16>(std::stol(value));
+                } else if (key == "ceil_height") {
+                    sector.ceiling_height = static_cast<i16>(std::stol(value));
+                } else if (key == "floor_tex") {
+                    sector.floor_texture = value;
+                } else if (key == "ceil_tex") {
+                    sector.ceiling_texture = value;
+                } else if (key == "ceil_tex") {
+                    sector.light_level = static_cast<u8>(std::stol(value));
+                }
+
+                std::cout << "\tParsed: [" << key << "]:[" << value << "]" << std::endl;
+            } else {
+                continue;
+            }
+
+            // Save the entity into a vector
+            sectors.push_back(sector);
+        }
+        return sectors;
+    }
 } // namespace YAML::Types

--- a/calamity/src/yaml/types.hpp
+++ b/calamity/src/yaml/types.hpp
@@ -61,22 +61,21 @@ namespace YAML::Types {
     // = Parser functors with specialization ====
     // ==========================================
     template <class T>
-    auto parse_functor(const FuncArgs& args) -> void;
-
-    // TODO: Make all parsing functions and move them to a source file
-    template <>
-    auto parse_functor<Level::Entity>(const FuncArgs& args) -> void;
+    auto parse_functor(const FuncArgs& args) -> std::vector<T>;
 
     template <>
-    auto parse_functor<Level::Vec2>(const FuncArgs& args) -> void;
+    auto parse_functor<Level::Entity>(const FuncArgs& args) -> std::vector<Level::Entity>;
 
     template <>
-    auto parse_functor<Level::Line>(const FuncArgs& args) -> void;
+    auto parse_functor<Level::Vec2>(const FuncArgs& args) -> std::vector<Level::Vec2>;
 
     template <>
-    auto parse_functor<Level::Side>(const FuncArgs& args) -> void;
+    auto parse_functor<Level::Line>(const FuncArgs& args) -> std::vector<Level::Line>;
 
     template <>
-    auto parse_functor<Level::Sector>(const FuncArgs& args) -> void;
+    auto parse_functor<Level::Side>(const FuncArgs& args) -> std::vector<Level::Side>;
+
+    template <>
+    auto parse_functor<Level::Sector>(const FuncArgs& args) -> std::vector<Level::Sector>;
 
 } // namespace YAML::Types


### PR DESCRIPTION
The point of this was to write less, not more, however I somewhat admit to failure.

I'll rewrite this later.

