### PR TITLE
py-build: Hash object filenames to prevent collisions

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,7 +16,7 @@
 -   [ ] Make the output of the tool neater.
 -   [ ] Refactor into smaller types and functions and make it more readable.
 -   [ ] Add support for building source files with the project (like `glad`) and not just static/shared libraries.
--   [ ] Add hash of filename to prevent name collisions when building and linking object files.
+-   [x] Add hash of filename to prevent name collisions when building and linking object files.
 
 ## tools/map-editor
 

--- a/tools/py-build/src/utils/types.py
+++ b/tools/py-build/src/utils/types.py
@@ -5,6 +5,7 @@ import os
 import shlex
 import subprocess as sp
 import sys
+import hashlib
 
 from flatdict import FlatDict # type: ignore
 import yaml # type: ignore
@@ -314,8 +315,12 @@ class Builder(Config):
         for source in self.build_files['sources']:
             src = source.name
 
+            # Get hash of the file
+            src_hash_raw = str(source).encode('utf-8')
+            src_hash = hashlib.md5(src_hash_raw).hexdigest()[:8]
+
             # Get destination file path
-            obj = self.dirs['build'] / f"{src.split('.')[0]}.o"
+            obj = self.dirs['build'] / f"{src.split('.')[0]}-{src_hash}.o"
 
             # Prepare vars for compiling
             includes = ' '.join(self.includes)


### PR DESCRIPTION
The collisions were happening due to an oversight, that we never care about paths.
The following addition completely nullifies that.